### PR TITLE
allow for guzzle 6.2 and 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.2 || ^7.0",
         "nesbot/carbon": "^2.0",
         "illuminate/support": "^5.8 || ^6.0 || ^7.0"
     },


### PR DESCRIPTION
 - saintsystems/odata-client 0.6.1 requires guzzlehttp/guzzle ^7.0 -> found guzzlehttp/guzzle[7.0.0, ..., 7.8.0] but it conflicts with your root composer.json require (^6.2).
 
 this is why we need to allow ^6.2 and ^7.0 for when we eventually move to guzzle 7 in rg_core